### PR TITLE
docs: fix spelling of lodash function names in doc comment

### DIFF
--- a/src/CleanDeep.resi
+++ b/src/CleanDeep.resi
@@ -1,7 +1,7 @@
 @ocaml.doc(" [rescript-clean-deep] is bindings for {{: https://github.com/nunofgs/clean-deep } [clean-deep]},
     a library for removing empty or nullable values from javascript objects.
 
-    [clean-deep] uses lodash ([isempty] and [isplainobject]) in addition to
+    [clean-deep] uses lodash ([isEmpty] and [isPlainObject]) in addition to
     checking for empty and nullable values to perform the actual cleaning of
     JS-objects.
  ")


### PR DESCRIPTION
isEmpty and isPlainObject were written in lowercase.